### PR TITLE
Added redis_key_func arg to the RedisBackend

### DIFF
--- a/starsessions/backends/redis.py
+++ b/starsessions/backends/redis.py
@@ -26,11 +26,11 @@ class RedisBackend(SessionBackend):
                 raise ImproperlyConfigured(
                     "The redis_key argument needs to be a callable and have a session_id argument"
                 )
-        self.redis_key = redis_key_func
+        self._redis_key_func = redis_key_func
 
     def get_redis_key(self, session_id: str) -> str:
-        if self.redis_key:
-            return self.redis_key(session_id)
+        if self._redis_key_func:
+            return self._redis_key_func(session_id)
         else:
             return session_id
 

--- a/starsessions/backends/redis.py
+++ b/starsessions/backends/redis.py
@@ -1,9 +1,6 @@
-import inspect
-
 import aioredis
 import typing
 
-from .. import ImproperlyConfigured
 from ..serializers import JsonSerializer, Serializer
 from .base import SessionBackend
 
@@ -22,10 +19,9 @@ class RedisBackend(SessionBackend):
         self._serializer = serializer or JsonSerializer()
         self._connection = connection or aioredis.from_url(url)
         if redis_key_func:
-            if not callable(redis_key_func) or "session_id" not in inspect.signature(redis_key_func).parameters.keys():
-                raise ImproperlyConfigured(
-                    "The redis_key_func needs to be a callable and have a session_id argument"
-                )
+            assert callable(
+                redis_key_func
+            ), "The redis_key_func needs to be a callable that takes a single string argument."
         self._redis_key_func = redis_key_func
 
     def get_redis_key(self, session_id: str) -> str:

--- a/starsessions/backends/redis.py
+++ b/starsessions/backends/redis.py
@@ -24,7 +24,7 @@ class RedisBackend(SessionBackend):
         if redis_key_func:
             if not callable(redis_key_func) or "session_id" not in inspect.signature(redis_key_func).parameters.keys():
                 raise ImproperlyConfigured(
-                    "The redis_key argument needs to be a callable and have a session_id argument"
+                    "The redis_key_func needs to be a callable and have a session_id argument"
                 )
         self._redis_key_func = redis_key_func
 

--- a/starsessions/backends/redis.py
+++ b/starsessions/backends/redis.py
@@ -1,6 +1,9 @@
+import inspect
+
 import aioredis
 import typing
 
+from .. import ImproperlyConfigured
 from ..serializers import JsonSerializer, Serializer
 from .base import SessionBackend
 
@@ -13,25 +16,38 @@ class RedisBackend(SessionBackend):
         url: str = None,
         connection: aioredis.Redis = None,
         serializer: Serializer = None,
+        redis_key_func: typing.Callable[[str], str] = None,
     ) -> None:
         assert url or connection, 'Either "url" or "connection" arguments must be provided.'
         self._serializer = serializer or JsonSerializer()
         self._connection = connection or aioredis.from_url(url)
+        if redis_key_func:
+            if not callable(redis_key_func) or "session_id" not in inspect.signature(redis_key_func).parameters.keys():
+                raise ImproperlyConfigured(
+                    "The redis_key argument needs to be a callable and have a session_id argument"
+                )
+        self.redis_key = redis_key_func
+
+    def get_redis_key(self, session_id: str) -> str:
+        if self.redis_key:
+            return self.redis_key(session_id)
+        else:
+            return session_id
 
     async def read(self, session_id: str) -> typing.Dict:
-        value = await self._connection.get(session_id)
+        value = await self._connection.get(self.get_redis_key(session_id))
         if value is None:
             return {}
         return self._serializer.deserialize(value)
 
     async def write(self, data: typing.Dict, session_id: typing.Optional[str] = None) -> str:
         session_id = session_id or await self.generate_id()
-        await self._connection.set(session_id, self._serializer.serialize(data))
+        await self._connection.set(self.get_redis_key(session_id), self._serializer.serialize(data))
         return session_id
 
     async def remove(self, session_id: str) -> None:
-        await self._connection.delete(session_id)
+        await self._connection.delete(self.get_redis_key(session_id))
 
     async def exists(self, session_id: str) -> bool:
-        result = await self._connection.exists(session_id)
+        result = await self._connection.exists(self.get_redis_key(session_id))
         return result > 0

--- a/tests/backends/test_redis.py
+++ b/tests/backends/test_redis.py
@@ -1,37 +1,51 @@
+import os
+from typing import Tuple, Dict, Any
+
 import pytest
 
-from starsessions import Session, SessionBackend
+from starsessions import Session, SessionBackend, ImproperlyConfigured
+from starsessions.backends.redis import RedisBackend
+from tests.conftest import redis_key_callable_wrong_arg_name
 
 
 @pytest.mark.asyncio
-async def test_redis_read_write(redis: SessionBackend, session_payload: dict) -> None:
+async def test_redis_read_write(redis_session_payload: Tuple[SessionBackend, Dict[str, str]]) -> None:
+    redis, session_payload = redis_session_payload
     new_id = await redis.write(session_payload, "session_id")
     assert new_id == "session_id"
     assert await redis.read("session_id") == session_payload
 
 
 @pytest.mark.asyncio
-async def test_redis_remove(redis: SessionBackend, session_payload: dict) -> None:
+async def test_redis_remove(
+    redis_session_payload: Tuple[SessionBackend, Dict[str, str]], session_payload: dict
+) -> None:
+    redis, session_payload = redis_session_payload
     await redis.write(session_payload, "session_id")
     await redis.remove("session_id")
     assert await redis.exists("session_id") is False
 
 
 @pytest.mark.asyncio
-async def test_redis_exists(redis: SessionBackend, session_payload: dict) -> None:
+async def test_redis_exists(
+    redis_session_payload: Tuple[SessionBackend, Dict[str, str]], session_payload: dict
+) -> None:
+    redis, session_payload = redis_session_payload
     await redis.write(session_payload, "session_id")
     assert await redis.exists("session_id") is True
     assert await redis.exists("other id") is False
 
 
 @pytest.mark.asyncio
-async def test_redis_generate_id(redis: SessionBackend) -> None:
+async def test_redis_generate_id(redis_session_payload: Tuple[SessionBackend, Dict[str, str]]) -> None:
+    redis, session_payload = redis_session_payload
     new_id = await redis.generate_id()
     assert isinstance(new_id, str)
 
 
 @pytest.mark.asyncio
-async def test_redis_empty_session(redis: SessionBackend) -> None:
+async def test_redis_empty_session(redis_session_payload: Tuple[SessionBackend, Dict[str, str]]) -> None:
+    redis, session_payload = redis_session_payload
     assert await redis.read("unknown_session_id") == {}
 
 
@@ -47,3 +61,12 @@ def test_session_is_modified(redis_session: Session) -> None:
 
     redis_session["key"] = "value"
     assert redis_session.is_modified is True
+
+
+@pytest.mark.parametrize("redis_key", [redis_key_callable_wrong_arg_name, "not_a_callable"])
+def test_improperly_configured_redis_key(redis_key: Any) -> None:
+    url = os.environ.get("REDIS_URL", "redis://localhost")
+    with pytest.raises(ImproperlyConfigured):
+        RedisBackend(url, redis_key_func=redis_key), {"key": "value"} if redis_key is None else {
+            redis_key("key"): "value"
+        }

--- a/tests/backends/test_redis.py
+++ b/tests/backends/test_redis.py
@@ -1,11 +1,10 @@
 import os
-from typing import Tuple, Dict, Any
+from typing import Tuple, Dict
 
 import pytest
 
-from starsessions import Session, SessionBackend, ImproperlyConfigured
+from starsessions import Session, SessionBackend
 from starsessions.backends.redis import RedisBackend
-from tests.conftest import redis_key_callable_wrong_arg_name
 
 
 @pytest.mark.asyncio
@@ -63,10 +62,7 @@ def test_session_is_modified(redis_session: Session) -> None:
     assert redis_session.is_modified is True
 
 
-@pytest.mark.parametrize("redis_key", [redis_key_callable_wrong_arg_name, "not_a_callable"])
-def test_improperly_configured_redis_key(redis_key: Any) -> None:
+def test_improperly_configured_redis_key() -> None:
     url = os.environ.get("REDIS_URL", "redis://localhost")
-    with pytest.raises(ImproperlyConfigured):
-        RedisBackend(url, redis_key_func=redis_key), {"key": "value"} if redis_key is None else {
-            redis_key("key"): "value"
-        }
+    with pytest.raises(AssertionError):
+        RedisBackend(url, redis_key_func="a_random_string")  # type: ignore[arg-type]

--- a/tests/backends/test_redis.py
+++ b/tests/backends/test_redis.py
@@ -1,4 +1,3 @@
-import os
 from typing import Tuple, Dict
 
 import pytest
@@ -63,6 +62,5 @@ def test_session_is_modified(redis_session: Session) -> None:
 
 
 def test_improperly_configured_redis_key() -> None:
-    url = os.environ.get("REDIS_URL", "redis://localhost")
     with pytest.raises(AssertionError):
-        RedisBackend(url, redis_key_func="a_random_string")  # type: ignore[arg-type]
+        RedisBackend(redis_key_func="a_random_string")  # type: ignore[arg-type]


### PR DESCRIPTION
Fixes #8 

Added a few tests also to raise the bad configuration exception.

I also had to transform the `redis` fixture into a redis_session_payload` one. I'm not too happy about it, it may look a little bit complicated, but I didn't find a better way to express that once configured with a callable then the old `session_payload` has to be changed as well, since the key will be different: the redis config in in a way tied to the session_payload we check for.

