### PR TITLE
Corrected middleware order

### DIFF
--- a/examples/fastapi_app.py
+++ b/examples/fastapi_app.py
@@ -19,8 +19,8 @@ from fastapi.responses import JSONResponse, RedirectResponse
 from starsessions import CookieStore, SessionAutoloadMiddleware, SessionMiddleware
 
 app = FastAPI()
-app.add_middleware(SessionMiddleware, store=CookieStore(secret_key="key"))
 app.add_middleware(SessionAutoloadMiddleware)
+app.add_middleware(SessionMiddleware, store=CookieStore(secret_key="key"))
 
 
 @app.get("/", response_class=JSONResponse)


### PR DESCRIPTION
for fastapi example the order seems incorrect to me, trying currently to upgrade from 1.2.3 and I faced this issue following the example, if order is incorrect this tb happens:

```python
Traceback (most recent call last):
  File "/home/lotso/.cache/pypoetry/virtualenvs/starsessions-5SyLMafa-py3.10/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 404, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/home/lotso/.cache/pypoetry/virtualenvs/starsessions-5SyLMafa-py3.10/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "/home/lotso/.cache/pypoetry/virtualenvs/starsessions-5SyLMafa-py3.10/lib/python3.10/site-packages/fastapi/applications.py", line 269, in __call__
    await super().__call__(scope, receive, send)
  File "/home/lotso/.cache/pypoetry/virtualenvs/starsessions-5SyLMafa-py3.10/lib/python3.10/site-packages/starlette/applications.py", line 124, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/lotso/.cache/pypoetry/virtualenvs/starsessions-5SyLMafa-py3.10/lib/python3.10/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/home/lotso/.cache/pypoetry/virtualenvs/starsessions-5SyLMafa-py3.10/lib/python3.10/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/home/lotso/PycharmProjects/starsessions/./starsessions/middleware.py", line 157, in __call__
    await load_session(connection)
  File "/home/lotso/PycharmProjects/starsessions/./starsessions/session.py", line 49, in load_session
    await get_session_handler(connection).load()
  File "/home/lotso/PycharmProjects/starsessions/./starsessions/session.py", line 39, in get_session_handler
    return typing.cast(SessionHandler, connection.scope["session_handler"])
KeyError: 'session_handler'
```