### PR TITLE
fix get_session_remaining_seconds() for rolling sessions

### DIFF
--- a/starsessions/middleware.py
+++ b/starsessions/middleware.py
@@ -66,7 +66,7 @@ class SessionMiddleware:
 
         connection = HTTPConnection(scope)
         session_id = connection.cookies.get(self.cookie_name)
-        handler = SessionHandler(connection, session_id, self.store, self.serializer, self.lifetime)
+        handler = SessionHandler(connection, session_id, self.rolling, self.store, self.serializer, self.lifetime)
 
         scope["session"] = LoadGuard()
         scope["session_handler"] = handler

--- a/starsessions/types.py
+++ b/starsessions/types.py
@@ -5,3 +5,4 @@ class SessionMetadata(typing.TypedDict):
     lifetime: int
     created: float  # timestamp
     last_access: float  # timestamp
+    last_update: float  # timestamp

--- a/tests/backends/test_redis.py
+++ b/tests/backends/test_redis.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 import redis.asyncio
-from pytest_asyncio.plugin import SubRequest
+from pytest import FixtureRequest
 
 from starsessions import ImproperlyConfigured
 from starsessions.stores.base import SessionStore
@@ -13,7 +13,7 @@ def redis_key_callable(session_id: str) -> str:
 
 
 @pytest.fixture(params=["prefix_", redis_key_callable], ids=["using string", "using redis_key_callable"])
-def redis_store(request: SubRequest) -> SessionStore:
+def redis_store(request: FixtureRequest) -> SessionStore:
     redis_key = request.param
     url = os.environ.get("REDIS_URL", "redis://localhost")
     return RedisStore(url, prefix=redis_key)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -37,6 +37,7 @@ def test_load_should_create_new_metadata(store: SessionStore) -> None:
             "created": 1660556520,
             "last_access": 1660556520,
             "lifetime": 1209600,
+            "rolling": False,
         }
 
 
@@ -59,6 +60,7 @@ def test_load_should_not_overwrite_created_timestamp(store: SessionStore) -> Non
             "created": 42,
             "last_access": 1660556520,
             "lifetime": 0,
+            "rolling": False,
         }
 
 
@@ -79,6 +81,7 @@ def test_should_update_last_access_time_on_load(store: SessionStore) -> None:
             "created": 1660556520,
             "last_access": 1660556520,
             "lifetime": 1209600,
+            "rolling": False,
         }
 
     with mock.patch("time.time", lambda: 1660556000):
@@ -86,4 +89,5 @@ def test_should_update_last_access_time_on_load(store: SessionStore) -> None:
             "created": 1660556520,
             "last_access": 1660556000,
             "lifetime": 1209600,
+            "rolling": False,
         }

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -22,7 +22,9 @@ def test_regenerate_session_id(store: SessionStore, serializer: Serializer) -> N
     base_session_id = "some_id"
     connection = HTTPConnection(scope)
     connection.scope["session"] = {}
-    connection.scope["session_handler"] = SessionHandler(connection, base_session_id, store, serializer, lifetime=60)
+    connection.scope["session_handler"] = SessionHandler(
+        connection, base_session_id, False, store, serializer, lifetime=60
+    )
 
     session_id = regenerate_session_id(connection)
     assert session_id
@@ -34,7 +36,9 @@ def test_get_session_id(store: SessionStore, serializer: Serializer) -> None:
     base_session_id = "some_id"
     connection = HTTPConnection(scope)
     connection.scope["session"] = {}
-    connection.scope["session_handler"] = SessionHandler(connection, base_session_id, store, serializer, lifetime=60)
+    connection.scope["session_handler"] = SessionHandler(
+        connection, base_session_id, False, store, serializer, lifetime=60
+    )
 
     session_id = get_session_id(connection)
     assert session_id == base_session_id
@@ -45,7 +49,9 @@ def test_get_session_handler(store: SessionStore, serializer: Serializer) -> Non
     base_session_id = "some_id"
     connection = HTTPConnection(scope)
     connection.scope["session"] = {}
-    connection.scope["session_handler"] = SessionHandler(connection, base_session_id, store, serializer, lifetime=60)
+    connection.scope["session_handler"] = SessionHandler(
+        connection, base_session_id, False, store, serializer, lifetime=60
+    )
 
     assert get_session_handler(connection) == connection.scope["session_handler"]
 
@@ -56,7 +62,9 @@ async def test_load_session(store: SessionStore, serializer: Serializer) -> None
     base_session_id = "session_id"
     connection = HTTPConnection(scope)
     connection.scope["session"] = {}
-    connection.scope["session_handler"] = SessionHandler(connection, base_session_id, store, serializer, lifetime=60)
+    connection.scope["session_handler"] = SessionHandler(
+        connection, base_session_id, False, store, serializer, lifetime=60
+    )
 
     await store.write("session_id", b'{"key": "value"}', lifetime=60, ttl=60)
     await load_session(connection)


### PR DESCRIPTION
`get_session_remaining_seconds()` should return `last_update + lifetime - now` instead of `created + lifetime - now`.