### PR TITLE
Add database backend.

### DIFF
--- a/examples/database_.py
+++ b/examples/database_.py
@@ -1,0 +1,85 @@
+"""
+This example demonstrates Database store usage.
+
+You can change database connection by specifying DATABASE_URL environment variable.
+
+This example requires `databases` to be installed:
+> pip install databases
+
+Usage:
+> uvicorn examples.database:app
+
+Open http://localhost:8000 for management panel.
+"""
+
+import contextlib
+import datetime
+import json
+import os
+import typing
+
+from databases import Database
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, RedirectResponse
+from starlette.routing import Route
+
+from starsessions import SessionAutoloadMiddleware, SessionMiddleware
+from starsessions.stores.database import DatabaseStore, create_table
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://starsessions_demo")
+
+
+async def homepage(request: Request) -> HTMLResponse:
+    """Access this view (GET "/") to display session contents."""
+
+    # built-in json.dumps cannot serialize Session object, convert it to dict first
+    return HTMLResponse(
+        f"<div>session data: {json.dumps(request.session)}</div>"
+        "<ol>"
+        '<li><a href="/set">set example data</a></li>'
+        '<li><a href="/clean">clear example data</a></li>'
+        "</ol>"
+    )
+
+
+async def set_time(request: Request) -> RedirectResponse:
+    """Access this view (GET "/set") to set session contents."""
+    request.session["hello"] = "world"
+    request.session["date"] = datetime.datetime.now().isoformat()
+    return RedirectResponse("/")
+
+
+async def clean(request: Request) -> RedirectResponse:
+    """Access this view (GET "/clean") to remove all session contents."""
+    request.session.clear()
+    return RedirectResponse("/")
+
+
+database = Database(DATABASE_URL)
+
+
+@contextlib.asynccontextmanager
+async def lifespan(app: Starlette) -> typing.AsyncGenerator[typing.Dict[str, typing.Any], None]:
+    async with database:
+        await database.connect()
+
+        # In normal operation Alembic should be used to create tables instead of calling create_table
+        await create_table(database)
+
+        yield {}
+
+        await database.disconnect()
+
+
+routes = [
+    Route("/", endpoint=homepage),
+    Route("/set", endpoint=set_time),
+    Route("/clean", endpoint=clean),
+]
+middleware = [
+    Middleware(SessionMiddleware, store=DatabaseStore(database=database), lifetime=10, rolling=True),
+    Middleware(SessionAutoloadMiddleware),
+]
+app = Starlette(debug=True, routes=routes, middleware=middleware, lifespan=lifespan)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ python = "^3.8.0"
 starlette = "*"
 itsdangerous = "^2"
 redis = { version = ">=4.2.0rc1", optional = true }
+database = { version = ">=0.9.0", optional = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"
@@ -37,6 +38,7 @@ pytest-cov = "5.0.0"
 mypy = "1.11.2"
 fastapi = "0.115.0"
 redis = ">=4.2.0rc1"
+aiosqlite = ">=0.21.0"
 httpx = "^0.27.2"
 
 [tool.poetry.extras]

--- a/starsessions/stores/database.py
+++ b/starsessions/stores/database.py
@@ -1,0 +1,94 @@
+import datetime
+import typing
+
+import databases
+
+from sqlalchemy.schema import CreateTable
+from sqlalchemy import Column, String, LargeBinary, DateTime, MetaData, Table
+
+from starsessions.exceptions import ImproperlyConfigured
+from starsessions.stores.base import SessionStore
+
+metadata = MetaData()
+
+session_data = Table(
+    "session_data",
+    metadata,
+    Column("id", String, primary_key=True),
+    Column("data", LargeBinary),
+    Column("expires_at", DateTime, index=True),
+)
+
+
+async def create_table(database: databases.Database, if_not_exists: bool = True) -> None:
+    """
+    Create the session_data table in the database, this is for use
+    during development or testing.
+
+    In normal operation Alembic should be used to create tables.
+
+    :param database: A databases.Database instance.
+    :param if_not_exists: Set `if_not_exists=False` if you want the
+    query to throw an exception when the table already exists.
+    """
+    for table in metadata.tables.values():
+        schema = CreateTable(table, if_not_exists=if_not_exists)
+        query = str(schema.compile())
+        await database.execute(query=query)
+
+
+class DatabaseStore(SessionStore):
+    """Stores session data in a database using SQLAlchemy."""
+
+    def __init__(self, database: typing.Optional[databases.Database] = None, gc_ttl: int = 3600 * 24 * 30) -> None:
+        """Initialize the session with a Database instance.
+
+        :param database: A databases.Database instance
+        :param gc_ttl: TTL for sessions that have no expiration time
+        """
+
+        if not database:
+            raise ImproperlyConfigured("'database' argument must be provided.")
+
+        self.database = database
+        self.gc_ttl = gc_ttl
+
+    async def read(self, session_id: str, lifetime: int) -> bytes:
+        """Read session data from the database."""
+        query = session_data.select().where(session_data.c.id == session_id)
+        result = await self.database.fetch_one(query)
+        if result is None:
+            return b""
+
+        if result["expires_at"] < datetime.datetime.utcnow():
+            await self.remove(session_id)
+            return b""
+
+        return bytes(result["data"])
+
+    async def write(self, session_id: str, data: bytes, lifetime: int, ttl: int) -> str:
+        """Write session data to the database."""
+        if lifetime == 0:
+            # Use gc_ttl for session-only cookies, as zero is not a valid expiry value
+            ttl = self.gc_ttl
+
+        ttl = max(1, ttl)
+        expires_at = datetime.datetime.utcnow() + datetime.timedelta(seconds=ttl)
+
+        query = session_data.select().where(session_data.c.id == session_id)
+        existing = await self.database.fetch_one(query)
+
+        if existing:
+            query = (
+                session_data.update().where(session_data.c.id == session_id).values(data=data, expires_at=expires_at)
+            )
+        else:
+            query = session_data.insert().values(id=session_id, data=data, expires_at=expires_at)
+
+        await self.database.execute(query)
+        return session_id
+
+    async def remove(self, session_id: str) -> None:
+        """Remove session data from the database."""
+        query = session_data.delete().where(session_data.c.id == session_id)
+        await self.database.execute(query)

--- a/tests/backends/test_database.py
+++ b/tests/backends/test_database.py
@@ -1,0 +1,105 @@
+import datetime
+import os
+from typing import AsyncGenerator
+
+import databases
+import pytest
+
+from databases import Database
+
+from starsessions import ImproperlyConfigured
+from starsessions.stores.database import DatabaseStore, create_table, session_data
+
+DATABASE_URL = os.environ.get("TEST_DATABASE_URL", "sqlite:///./test.db")
+
+
+@pytest.fixture
+async def database() -> AsyncGenerator[Database, None]:
+    """Create a test database connection."""
+    database = Database(DATABASE_URL)
+    await database.connect()
+    await create_table(database)
+
+    yield database
+
+    # Clean up
+    if DATABASE_URL.startswith("sqlite"):
+        await database.execute("DROP TABLE IF EXISTS session_data")
+    else:
+        await database.execute("DROP TABLE IF EXISTS session_data CASCADE")
+    await database.disconnect()
+
+
+async def test_database_read_write(database: databases.Database) -> None:
+    """Test basic read and write operations."""
+    db_store = DatabaseStore(database=database)
+
+    new_id = await db_store.write("session_id", b"data", lifetime=60, ttl=60)
+    assert new_id == "session_id"
+    assert await db_store.read("session_id", lifetime=60) == b"data"
+
+
+async def test_database_write_with_session_only_setup(database: databases.Database) -> None:
+    """Test writing with session-only setup (lifetime=0)."""
+    db_store = DatabaseStore(database=database)
+    await db_store.write("session_id", b"data", lifetime=0, ttl=0)
+
+
+async def test_database_remove(database: databases.Database) -> None:
+    """Test removing session data."""
+    db_store = DatabaseStore(database=database)
+
+    await db_store.write("session_id", b"data", lifetime=60, ttl=60)
+    await db_store.remove("session_id")
+    assert await db_store.read("session_id", lifetime=60) == b""
+
+
+async def test_database_empty_session(database: databases.Database) -> None:
+    """Test reading a non-existent session."""
+    db_store = DatabaseStore(database=database)
+    assert await db_store.read("unknown_session_id", lifetime=60) == b""
+
+
+async def test_database_expired_session(database: databases.Database) -> None:
+    """Test reading an expired session."""
+    db_store = DatabaseStore(database=database)
+
+    # Insert expired session directly
+    expires_at = datetime.datetime.utcnow() - datetime.timedelta(seconds=10)
+    query = session_data.insert().values(id="expired_session", data=b"expired_data", expires_at=expires_at)
+    await database.execute(query)
+
+    assert await db_store.read("expired_session", lifetime=60) == b""
+
+    # Verify it was removed due to expiration
+    query = session_data.select().where(session_data.c.id == "expired_session")
+    assert await database.fetch_one(query) is None
+
+
+async def test_database_update_session(database: databases.Database) -> None:
+    """Test updating an existing session."""
+    db_store = DatabaseStore(database=database)
+
+    await db_store.write("session_id", b"initial_data", lifetime=60, ttl=60)
+    await db_store.write("session_id", b"updated_data", lifetime=60, ttl=120)
+    assert await db_store.read("session_id", lifetime=60) == b"updated_data"
+
+
+async def test_database_requires_database() -> None:
+    """Test that a database connection is required."""
+    with pytest.raises(ImproperlyConfigured):
+        DatabaseStore()
+
+
+async def test_custom_gc_ttl(database: databases.Database) -> None:
+    """Test setting a custom gc_ttl value."""
+    custom_ttl = 3600
+    db_store = DatabaseStore(database=database, gc_ttl=custom_ttl)
+
+    await db_store.write("session_id", b"data", lifetime=0, ttl=0)
+
+    # Verify the correct TTL was used
+    query = session_data.select().where(session_data.c.id == "session_id")
+    result = await database.fetch_one(query)
+    expected_expires = datetime.datetime.utcnow() + datetime.timedelta(seconds=custom_ttl)
+    assert abs((result["expires_at"] - expected_expires).total_seconds()) < 5

--- a/tests/backends/test_database.py
+++ b/tests/backends/test_database.py
@@ -1,9 +1,8 @@
 import datetime
 import os
-from typing import AsyncGenerator
-
 import databases
 import pytest
+import typing
 
 from databases import Database
 
@@ -14,8 +13,7 @@ DATABASE_URL = os.environ.get("TEST_DATABASE_URL", "sqlite:///./test.db")
 
 
 @pytest.fixture
-async def database() -> AsyncGenerator[Database, None]:
-    """Create a test database connection."""
+async def database() -> typing.AsyncGenerator[Database, None]:
     database = Database(DATABASE_URL)
     await database.connect()
     await create_table(database)
@@ -31,7 +29,6 @@ async def database() -> AsyncGenerator[Database, None]:
 
 
 async def test_database_read_write(database: databases.Database) -> None:
-    """Test basic read and write operations."""
     db_store = DatabaseStore(database=database)
 
     new_id = await db_store.write("session_id", b"data", lifetime=60, ttl=60)
@@ -40,13 +37,11 @@ async def test_database_read_write(database: databases.Database) -> None:
 
 
 async def test_database_write_with_session_only_setup(database: databases.Database) -> None:
-    """Test writing with session-only setup (lifetime=0)."""
     db_store = DatabaseStore(database=database)
     await db_store.write("session_id", b"data", lifetime=0, ttl=0)
 
 
 async def test_database_remove(database: databases.Database) -> None:
-    """Test removing session data."""
     db_store = DatabaseStore(database=database)
 
     await db_store.write("session_id", b"data", lifetime=60, ttl=60)
@@ -55,13 +50,11 @@ async def test_database_remove(database: databases.Database) -> None:
 
 
 async def test_database_empty_session(database: databases.Database) -> None:
-    """Test reading a non-existent session."""
     db_store = DatabaseStore(database=database)
     assert await db_store.read("unknown_session_id", lifetime=60) == b""
 
 
 async def test_database_expired_session(database: databases.Database) -> None:
-    """Test reading an expired session."""
     db_store = DatabaseStore(database=database)
 
     # Insert expired session directly
@@ -77,7 +70,6 @@ async def test_database_expired_session(database: databases.Database) -> None:
 
 
 async def test_database_update_session(database: databases.Database) -> None:
-    """Test updating an existing session."""
     db_store = DatabaseStore(database=database)
 
     await db_store.write("session_id", b"initial_data", lifetime=60, ttl=60)
@@ -86,13 +78,11 @@ async def test_database_update_session(database: databases.Database) -> None:
 
 
 async def test_database_requires_database() -> None:
-    """Test that a database connection is required."""
     with pytest.raises(ImproperlyConfigured):
         DatabaseStore()
 
 
 async def test_custom_gc_ttl(database: databases.Database) -> None:
-    """Test setting a custom gc_ttl value."""
     custom_ttl = 3600
     db_store = DatabaseStore(database=database, gc_ttl=custom_ttl)
 


### PR DESCRIPTION
Started adding a database backend, as a straight port of the redis backend let me know if there's interest in upstreaming this.

This access uses the `databases` module.
https://pypi.org/project/databases/

Which provides async access to SQLAlchemy core.

I'm mostly interested in using this from Postgres, but we get everything SQLALchemy core supports.

Session data is stored as a bytes, the same as the existing data stores (like the Redis store this is a port of).
In future it would be nice to support other data types - or at least JSON, since there is native support for this in databases now, but that's outside the scope of this PR.

Tasks

- [x] Impement initial backend
- [x] Port example from Redis
   - [x] Test on postgres
   - [x] Test on sqlite

- [x] Port unit test from Redis
   - [ ] Test on postgres
   - [x] Test on sqlite

- [ ] Work out what to do with CI
   Testing on sqlite is straightforward
   Postgres test, using something like pg-mem / something from the market place.

- [ ] pyproject.toml
   Probably need a way of adding the different databases the Databases module supports

Documentation
 - [ ] Example in README, add info on migrations (making this work with Alembic)

Questions:
How to support clearing the old sessions ?
Probably need a new API for this.