### PR TITLE
feat: session encryption, InMemoryStore TTL, and security hardening

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,5 @@ repos:
                     - redis
                     - itsdangerous
                     - fastapi
+                    - starlette
+                    - cryptography

--- a/README.md
+++ b/README.md
@@ -241,6 +241,31 @@ Class: `starsessions.CookieStore`
 
 Stores session data in a signed cookie on the client. No server-side storage required.
 
+> **Security notice — confidentiality**
+>
+> `CookieStore` **signs** session data (using HMAC) to prevent tampering, but it does **not encrypt** it by default.
+> Any user can base64-decode their cookie and read all session data in plaintext.
+>
+> **Never store sensitive data** (passwords, tokens, PII, roles) in a `CookieStore` session unless you also configure an encryptor:
+>
+> ```python
+> from cryptography.fernet import Fernet
+> from starsessions.encryptors import FernetEncryptor
+>
+> key = Fernet.generate_key()  # store this securely, e.g. in an env var
+> encryptor = FernetEncryptor(key)
+>
+> middleware = [
+>     Middleware(
+>         SessionMiddleware,
+>         store=CookieStore(secret_key="..."),
+>         encryptor=encryptor,
+>     )
+> ]
+> ```
+>
+> See the [Encryption](#encryption) section below for all available encryptors.
+
 ### Redis
 
 Class: `starsessions.stores.redis.RedisStore`
@@ -342,6 +367,79 @@ and `ttl` is the remaining session time. After `ttl` seconds the data can be saf
 > In such cases you don't have an exact expiration value, and you would have to find a way to extend the session TTL
 > on the storage side, if any.
 
+## Encryption
+
+Session data can be encrypted at rest (in the cookie or in the backend store) by passing an `encryptor` to `SessionMiddleware`.
+This is especially important when using `CookieStore`, where session data is stored on the client.
+
+Two built-in encryptors are available:
+
+### FernetEncryptor
+
+Uses AES-128-CBC + HMAC-SHA256 via the [`cryptography`](https://cryptography.io) library.
+Fernet is the recommended choice — it is simple, audited, and handles key rotation well.
+
+> Requires: `pip install cryptography`
+
+```python
+from cryptography.fernet import Fernet
+from starlette.middleware import Middleware
+from starsessions import CookieStore, SessionMiddleware
+from starsessions.encryptors import FernetEncryptor
+
+# generate once and store securely (e.g. ENCRYPTION_KEY env var).
+# rotating keys: pass a MultiFernet instance wrapping old + new keys.
+key = Fernet.generate_key()
+
+middleware = [
+    Middleware(
+        SessionMiddleware,
+        store=CookieStore(secret_key="..."),
+        encryptor=FernetEncryptor(key),
+    )
+]
+```
+
+### AESGCMEncryptor
+
+Uses AES-GCM (256-bit key) via the [`cryptography`](https://cryptography.io) library.
+A fresh random 12-byte nonce is generated for every write and prepended to the ciphertext.
+
+> Requires: `pip install cryptography`
+
+```python
+import os
+from starlette.middleware import Middleware
+from starsessions import CookieStore, SessionMiddleware
+from starsessions.encryptors import AESGCMEncryptor
+
+key = os.urandom(32)  # 256-bit key — store securely, never hard-code
+
+middleware = [
+    Middleware(
+        SessionMiddleware,
+        store=CookieStore(secret_key="..."),
+        encryptor=AESGCMEncryptor(key),
+    )
+]
+```
+
+### Custom encryptor
+
+Implement the `starsessions.encryptors.Encryptor` abstract class:
+
+```python
+from starsessions.encryptors import Encryptor
+
+
+class MyEncryptor(Encryptor):
+    async def encrypt(self, data: bytes) -> bytes:
+        ...
+
+    async def decrypt(self, data: bytes) -> bytes:
+        ...
+```
+
 ## Serializers
 
 Session data is serialized to JSON by default (`starsessions.JsonSerializer`). Implement `starsessions.Serializer` to use a custom format:
@@ -387,3 +485,15 @@ async def login(request):
     regenerate_session_id(request)
     return Response('successfully signed in')
 ```
+
+## Concurrent requests and session consistency
+
+Session reads and writes are **not atomic**. If two requests arrive simultaneously for the same session, both will read the current state, modify it independently, and write back — the last writer wins and silently overwrites the first writer's changes.
+
+This is a known trade-off shared by virtually all cookie/token-based session libraries. It is rarely a problem in practice because browser clients issue one request at a time for most flows.
+
+If your application issues multiple parallel API calls from the same client and all of them modify the session, consider one of these strategies:
+
+- **Design sessions to be append-only** — write only keys that a given endpoint owns so there is no overlap.
+- **Per-session locking (single-process)** — use an `asyncio.Lock` keyed on session ID. Works within a single process but not across multiple workers or pods.
+- **Atomic Redis operations (multi-process)** — implement a `RedisStore` subclass that uses a Lua script or `SET ... NX` to perform compare-and-swap on write, returning a conflict error that the caller retries.

--- a/examples/expiring.py
+++ b/examples/expiring.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "starsessions",
+#   "uvicorn",
+# ]
+# ///
 """
 This example demonstrates base usage of this library. The session will expire in 10 seconds after creation.
 
@@ -10,6 +17,7 @@ Open http://localhost:8000 for demo page.
 import datetime
 import json
 
+import uvicorn
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.requests import Request
@@ -57,3 +65,6 @@ middleware = [
     Middleware(SessionAutoloadMiddleware),
 ]
 app = Starlette(debug=True, routes=routes, middleware=middleware)
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/examples/fastapi_app.py
+++ b/examples/fastapi_app.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "fastapi[standard]",
+#   "starsessions",
+# ]
+# ///
 """
 This examples demonstrates integration with FastAPI.
 
@@ -14,6 +21,7 @@ access localhost:8000/clean to clear session data
 import datetime
 import typing
 
+import uvicorn
 from fastapi import FastAPI
 from fastapi.requests import Request
 from fastapi.responses import JSONResponse, RedirectResponse
@@ -43,3 +51,7 @@ async def clean(request: Request) -> str:
     """Access this view (GET '/clean') to remove all session contents."""
     request.session.clear()
     return "/"
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/examples/login.py
+++ b/examples/login.py
@@ -9,6 +9,8 @@ Usage:
 Open http://localhost:8000 for demo page.
 """
 
+import html
+
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.requests import Request
@@ -52,7 +54,7 @@ async def profile(request: Request) -> Response:
 
     return HTMLResponse(
         f"""
-    <p>Hi, {username}!</p>
+    <p>Hi, {html.escape(username)}!</p>
     <form method="post" action="/logout">
     <button type="submit">logout</button>
     </form>

--- a/examples/login.py
+++ b/examples/login.py
@@ -1,3 +1,11 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "python-multipart",
+#   "starsessions",
+#   "uvicorn",
+# ]
+# ///
 """
 This example demonstrates a simple login/logout flow.
 
@@ -11,6 +19,7 @@ Open http://localhost:8000 for demo page.
 
 import html
 
+import uvicorn
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.requests import Request
@@ -77,3 +86,6 @@ middleware = [
     Middleware(SessionAutoloadMiddleware),
 ]
 app = Starlette(debug=True, routes=routes, middleware=middleware)
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/examples/redis_.py
+++ b/examples/redis_.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "starsessions[redis]",
+#   "uvicorn",
+# ]
+# ///
 """
 This example demonstrates Redis store usage.
 

--- a/examples/rolling.py
+++ b/examples/rolling.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "starsessions",
+#   "uvicorn",
+# ]
+# ///
 """
 This example demonstrates base usage of this library. The session will expire in 10 seconds of inactivity but will be
 extended by another 10 seconds while you use the demo.
@@ -11,6 +18,7 @@ Open http://localhost:8000 for demo page.
 import datetime
 import json
 
+import uvicorn
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.requests import Request
@@ -59,3 +67,6 @@ middleware = [
     Middleware(SessionAutoloadMiddleware),
 ]
 app = Starlette(debug=True, routes=routes, middleware=middleware)
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/examples/session_only.py
+++ b/examples/session_only.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "starsessions",
+#   "uvicorn",
+# ]
+# ///
 """
 This example demonstrates session-only cookies.
 
@@ -18,6 +25,7 @@ Open http://localhost:8000 for demo page.
 import datetime
 import json
 
+import uvicorn
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.requests import Request
@@ -60,3 +68,6 @@ middleware = [
     Middleware(SessionAutoloadMiddleware),
 ]
 app = Starlette(debug=True, routes=routes, middleware=middleware)
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
 
 [project.optional-dependencies]
 redis = ["redis>=4.2"]
+cryptography = ["cryptography>=42"]
+all =  ["redis>=4.2", "cryptography>=42"]
 
 [project.urls]
 Homepage = "https://github.com/alex-oleshkevich/starsessions"
@@ -52,6 +54,7 @@ dev = [
     "mypy>=1.14",
     "redis>=4.2",
     "httpx>=0.28",
+    "cryptography>=42",
 ]
 
 [tool.coverage.run]
@@ -79,6 +82,9 @@ asyncio_mode = 'auto'
 asyncio_default_fixture_loop_scope = 'session'
 python_files = ["tests.py", "test_*.py", "*_tests.py"]
 addopts = "--tb=short -s --no-cov-on-fail"
+filterwarnings = [
+    "ignore::UserWarning:starsessions.encryptors",
+]
 testpaths = ["tests"]
 norecursedirs = [
     "node_modules", "frontend", "storage", "dist", ".git",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[flake8]
-ignore = W503, E203, B305, E225
-max-line-length = 120
-show-source = True
-statistics = True
-count = True
-max-complexity = 15

--- a/starsessions/encryptors.py
+++ b/starsessions/encryptors.py
@@ -1,25 +1,24 @@
 import abc
 import os
 import warnings
-from asyncio import to_thread
 
 
 class Encryptor(abc.ABC):
-    async def encrypt(self, data: bytes) -> bytes:
+    def encrypt(self, data: bytes) -> bytes:
         raise NotImplementedError
 
-    async def decrypt(self, data: bytes) -> bytes:
+    def decrypt(self, data: bytes) -> bytes:
         raise NotImplementedError
 
 
 class NoopEncryptor(Encryptor):
-    async def encrypt(self, data: bytes) -> bytes:
+    def encrypt(self, data: bytes) -> bytes:
         warnings.warn(
             "NoopEncryptor is not secure and should not be used in production. Please, configure a secure encryptor."
         )
         return data
 
-    async def decrypt(self, data: bytes) -> bytes:
+    def decrypt(self, data: bytes) -> bytes:
         return data
 
 
@@ -33,11 +32,11 @@ class FernetEncryptor(Encryptor):
         self.fernet = Fernet(key)
         self.key = key
 
-    async def encrypt(self, data: bytes) -> bytes:
-        return await to_thread(self.fernet.encrypt, data)
+    def encrypt(self, data: bytes) -> bytes:
+        return self.fernet.encrypt(data)
 
-    async def decrypt(self, data: bytes) -> bytes:
-        return await to_thread(self.fernet.decrypt, data)
+    def decrypt(self, data: bytes) -> bytes:
+        return self.fernet.decrypt(data)
 
 
 class AESGCMEncryptor(Encryptor):
@@ -50,13 +49,13 @@ class AESGCMEncryptor(Encryptor):
         self.aesgcm = AESGCM(key)
         self.key = key
 
-    async def encrypt(self, data: bytes) -> bytes:
+    def encrypt(self, data: bytes) -> bytes:
         nonce = os.urandom(12)
-        ciphertext = await to_thread(self.aesgcm.encrypt, nonce, data, None)
+        ciphertext = self.aesgcm.encrypt(nonce, data, None)
         return nonce + ciphertext
 
-    async def decrypt(self, data: bytes) -> bytes:
+    def decrypt(self, data: bytes) -> bytes:
         if len(data) < 12:
             return b""
         nonce, ciphertext = data[:12], data[12:]
-        return await to_thread(self.aesgcm.decrypt, nonce, ciphertext, None)
+        return self.aesgcm.decrypt(nonce, ciphertext, None)

--- a/starsessions/encryptors.py
+++ b/starsessions/encryptors.py
@@ -1,0 +1,62 @@
+import abc
+import os
+import warnings
+from asyncio import to_thread
+
+
+class Encryptor(abc.ABC):
+    async def encrypt(self, data: bytes) -> bytes:
+        raise NotImplementedError
+
+    async def decrypt(self, data: bytes) -> bytes:
+        raise NotImplementedError
+
+
+class NoopEncryptor(Encryptor):
+    async def encrypt(self, data: bytes) -> bytes:
+        warnings.warn(
+            "NoopEncryptor is not secure and should not be used in production. Please, configure a secure encryptor."
+        )
+        return data
+
+    async def decrypt(self, data: bytes) -> bytes:
+        return data
+
+
+class FernetEncryptor(Encryptor):
+    def __init__(self, key: bytes):
+        try:
+            from cryptography.fernet import Fernet
+        except ImportError:  # pragma: no cover
+            raise ImportError("cryptography is required for FernetEncryptor")
+
+        self.fernet = Fernet(key)
+        self.key = key
+
+    async def encrypt(self, data: bytes) -> bytes:
+        return await to_thread(self.fernet.encrypt, data)
+
+    async def decrypt(self, data: bytes) -> bytes:
+        return await to_thread(self.fernet.decrypt, data)
+
+
+class AESGCMEncryptor(Encryptor):
+    def __init__(self, key: bytes):
+        try:
+            from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+        except ImportError:  # pragma: no cover
+            raise ImportError("cryptography is required for AESGCMEncryptor")
+
+        self.aesgcm = AESGCM(key)
+        self.key = key
+
+    async def encrypt(self, data: bytes) -> bytes:
+        nonce = os.urandom(12)
+        ciphertext = await to_thread(self.aesgcm.encrypt, nonce, data, None)
+        return nonce + ciphertext
+
+    async def decrypt(self, data: bytes) -> bytes:
+        if len(data) < 12:
+            return b""
+        nonce, ciphertext = data[:12], data[12:]
+        return await to_thread(self.aesgcm.decrypt, nonce, ciphertext, None)

--- a/starsessions/middleware.py
+++ b/starsessions/middleware.py
@@ -9,6 +9,7 @@ from starlette.requests import HTTPConnection
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from starsessions import SessionNotLoaded
+from starsessions.encryptors import Encryptor, NoopEncryptor
 from starsessions.serializers import JsonSerializer, Serializer
 from starsessions.session import (
     SessionHandler,
@@ -16,6 +17,12 @@ from starsessions.session import (
     load_session,
 )
 from starsessions.stores import SessionStore
+
+_SAFE_COOKIE_VALUE_RE = re.compile(r"^[A-Za-z0-9\-._~+/=]+$")
+
+
+def _is_safe_cookie_value(value: str) -> bool:
+    return bool(_SAFE_COOKIE_VALUE_RE.match(value))
 
 
 class LoadGuard:
@@ -27,10 +34,10 @@ class LoadGuard:
 
         self._raise()
 
-    def __setitem__(self, key: str, value: typing.Any) -> typing.NoReturn:  # pragma: nocover
+    def __setitem__(self, key: str, value: typing.Any) -> typing.NoReturn:  # pragma: no cover
         self._raise()
 
-    def __getitem__(self, key: str) -> typing.NoReturn:  # pragma: nocover
+    def __getitem__(self, key: str) -> typing.NoReturn:  # pragma: no cover
         self._raise()
 
     def _raise(self) -> typing.NoReturn:
@@ -50,14 +57,20 @@ class SessionMiddleware:
         cookie_domain: str | None = None,
         cookie_path: str | None = None,
         serializer: Serializer | None = None,
+        encryptor: Encryptor | None = None,
     ) -> None:
         lifetime = int(lifetime.total_seconds() if isinstance(lifetime, datetime.timedelta) else lifetime)
         assert lifetime >= 0, "Session lifetime cannot be less than zero seconds."
+        if not re.match(r"^[a-zA-Z0-9_-]+$", cookie_name):
+            raise ValueError(
+                f"Invalid cookie_name {cookie_name!r}: must contain only alphanumeric characters, hyphens, or underscores."
+            )
 
         self.app = app
         self.store = store
         self.rolling = rolling
         self.serializer = serializer or JsonSerializer()
+        self.encryptor = encryptor or NoopEncryptor()
         self.cookie_name = cookie_name
         self.lifetime = lifetime
         self.cookie_domain = cookie_domain
@@ -72,8 +85,18 @@ class SessionMiddleware:
             return
 
         connection = HTTPConnection(scope)
-        session_id = connection.cookies.get(self.cookie_name)
-        handler = SessionHandler(connection, session_id, self.store, self.serializer, self.lifetime)
+        raw_session_id = connection.cookies.get(self.cookie_name)
+        # Reject values that contain characters unsafe in HTTP headers to prevent
+        # header injection if the session_id is ever echoed into Set-Cookie.
+        session_id = raw_session_id if raw_session_id and _is_safe_cookie_value(raw_session_id) else None
+        handler = SessionHandler(
+            connection=connection,
+            session_id=session_id,
+            store=self.store,
+            serializer=self.serializer,
+            lifetime=self.lifetime,
+            encryptor=self.encryptor,
+        )
 
         scope["session"] = LoadGuard()
         scope["session_handler"] = handler
@@ -84,7 +107,7 @@ class SessionMiddleware:
                 return
 
             # session was not loaded, do nothing
-            if not handler.is_loaded:  # pragma: nocover
+            if not handler.is_loaded:  # pragma: no cover
                 await send(message)
                 return
 

--- a/starsessions/session.py
+++ b/starsessions/session.py
@@ -114,7 +114,7 @@ class SessionHandler:
         if self.session_id:
             raw = await self.store.read(session_id=self.session_id, lifetime=self.lifetime)
             try:
-                data = self.serializer.deserialize(await self.encryptor.decrypt(raw))
+                data = self.serializer.deserialize(self.encryptor.decrypt(raw))
             except Exception:
                 data = {}
 
@@ -143,7 +143,7 @@ class SessionHandler:
 
         self.session_id = await self.store.write(
             session_id=self.session_id or generate_session_id(),
-            data=await self.encryptor.encrypt(
+            data=self.encryptor.encrypt(
                 self.serializer.serialize(self.connection.session),
             ),
             lifetime=self.lifetime,

--- a/starsessions/session.py
+++ b/starsessions/session.py
@@ -6,6 +6,7 @@ import typing
 
 from starlette.requests import HTTPConnection
 
+from starsessions.encryptors import Encryptor
 from starsessions.exceptions import SessionNotLoaded
 from starsessions.serializers import Serializer
 from starsessions.stores import SessionStore
@@ -89,31 +90,33 @@ class SessionHandler:
         session_id: str | None,
         store: SessionStore,
         serializer: Serializer,
+        encryptor: Encryptor,
         lifetime: int,
     ) -> None:
         self.connection = connection
         self.session_id = session_id
         self.store = store
         self.serializer = serializer
+        self.encryptor = encryptor
         self.is_loaded = False
         self.initially_empty = False
         self.lifetime = lifetime
         self.metadata: SessionMetadata | None = None
+        self._remove_data_for_session: str | None = None
 
     async def load(self) -> None:
         # don't refresh existing session, it may contain user data
-        if self.is_loaded:  # pragma: nocover, IDK how to test it :(
+        if self.is_loaded:  # pragma: no cover
             return
 
         self.is_loaded = True
         data = {}
         if self.session_id:
-            data = self.serializer.deserialize(
-                await self.store.read(
-                    session_id=self.session_id,
-                    lifetime=self.lifetime,
-                ),
-            )
+            raw = await self.store.read(session_id=self.session_id, lifetime=self.lifetime)
+            try:
+                data = self.serializer.deserialize(await self.encryptor.decrypt(raw))
+            except Exception:
+                data = {}
 
         # read and merge metadata
         metadata = {
@@ -122,7 +125,12 @@ class SessionHandler:
             "last_access": time.time(),
         }
         metadata.update(data.pop("__metadata__", {}))
-        metadata.update({"last_access": time.time()})  # force update
+        metadata.update(
+            {
+                "last_access": time.time(),
+                "lifetime": self.lifetime,
+            },
+        )  # force update
         self.metadata = metadata  # type: ignore[assignment]
 
         self.connection.scope["session"] = {}
@@ -135,10 +143,15 @@ class SessionHandler:
 
         self.session_id = await self.store.write(
             session_id=self.session_id or generate_session_id(),
-            data=self.serializer.serialize(self.connection.session),
+            data=await self.encryptor.encrypt(
+                self.serializer.serialize(self.connection.session),
+            ),
             lifetime=self.lifetime,
             ttl=remaining_time,
         )
+        if self._remove_data_for_session:
+            await self.store.remove(self._remove_data_for_session)
+            self._remove_data_for_session = None
         return self.session_id
 
     async def destroy(self) -> None:
@@ -151,5 +164,6 @@ class SessionHandler:
         return len(self.connection.session) == 0
 
     def regenerate_id(self) -> str:
+        self._remove_data_for_session = self.session_id
         self.session_id = generate_session_id()
         return self.session_id

--- a/starsessions/stores/cookie.py
+++ b/starsessions/stores/cookie.py
@@ -11,8 +11,9 @@ from starsessions.stores.base import SessionStore
 class CookieStore(SessionStore):
     """Stores session data in the browser's cookie as a signed string."""
 
-    def __init__(self, secret_key: str | Secret):
+    def __init__(self, secret_key: str | Secret, max_size: int = 4096):
         self._signer = TimestampSigner(str(secret_key))
+        self.max_size = max_size
 
     async def read(self, session_id: str, lifetime: int) -> bytes:
         """A session_id is a signed session value."""
@@ -32,7 +33,13 @@ class CookieStore(SessionStore):
     async def write(self, session_id: str, data: bytes, lifetime: int, ttl: int) -> str:
         """The data is a session id in this storage."""
         encoded_data = b64encode(data)
-        return self._signer.sign(encoded_data).decode("utf-8")
+        signed = self._signer.sign(encoded_data)
+        if len(signed) > self.max_size:
+            raise ValueError(
+                f"Session data too large: {len(signed)} bytes exceeds the {self.max_size}-byte cookie limit. "
+                "Store less data in the session or switch to a server-side store."
+            )
+        return signed.decode("utf-8")
 
     async def remove(self, session_id: str) -> None:
         """Session data stored on client side - no way to remove it."""

--- a/starsessions/stores/memory.py
+++ b/starsessions/stores/memory.py
@@ -1,20 +1,44 @@
 from __future__ import annotations
 
+import dataclasses
+import time
+
 from starsessions.stores.base import SessionStore
+
+
+@dataclasses.dataclass
+class Record:
+    expires: int
+    value: bytes
 
 
 class InMemoryStore(SessionStore):
     """Stores session data in a dictionary."""
 
-    def __init__(self) -> None:
-        self.data: dict[str, bytes] = {}
+    def __init__(self, gc_ttl: int = 3600 * 24) -> None:
+        self.data: dict[str, Record] = {}
+        self.gc_ttl = gc_ttl
 
     async def read(self, session_id: str, lifetime: int) -> bytes:
-        return self.data.get(session_id, b"")
+        value = self.data.get(session_id)
+        if value is None:
+            return b""
+
+        if value.expires < time.time_ns():
+            self.data.pop(session_id, None)
+            return b""
+
+        return value.value
 
     async def write(self, session_id: str, data: bytes, lifetime: int, ttl: int) -> str:
-        self.data[session_id] = data
+        self._evict_expired()
+        effective_ttl = ttl if ttl > 0 else self.gc_ttl
+        self.data[session_id] = Record(expires=effective_ttl * 1_000_000_000 + time.time_ns(), value=data)
         return session_id
+
+    def _evict_expired(self) -> None:
+        now = time.time_ns()
+        self.data = {k: v for k, v in self.data.items() if v.expires >= now}
 
     async def remove(self, session_id: str) -> None:
         try:

--- a/tests/backends/test_cookie.py
+++ b/tests/backends/test_cookie.py
@@ -33,3 +33,18 @@ async def test_returns_empty_string_for_bad_signature(
 ) -> None:
     # the session_id value is a signed session cookie value
     assert await cookie_store.read("session_id", lifetime=10) == b""
+
+
+@pytest.mark.asyncio
+async def test_cookie_max_size_enforced() -> None:
+    store = CookieStore("key", max_size=50)
+    with pytest.raises(ValueError, match="too large"):
+        await store.write("session_id", b"x" * 100, lifetime=60, ttl=60)
+
+
+@pytest.mark.asyncio
+async def test_cookie_max_size_not_exceeded() -> None:
+    store = CookieStore("key", max_size=4096)
+    # small payload must succeed
+    new_id = await store.write("session_id", b"hello", lifetime=60, ttl=60)
+    assert await store.read(new_id, lifetime=60) == b"hello"

--- a/tests/backends/test_memory.py
+++ b/tests/backends/test_memory.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from starsessions.stores import InMemoryStore, SessionStore
@@ -9,14 +11,48 @@ def in_memory_store() -> SessionStore:
 
 
 @pytest.mark.asyncio
-async def test_in_memory_read_write(in_memory_store: SessionStore) -> None:
+async def test_in_memory_read_write(in_memory_store: InMemoryStore) -> None:
     new_id = await in_memory_store.write("session_id", b"data", lifetime=60, ttl=60)
     assert new_id == "session_id"
     assert await in_memory_store.read("session_id", lifetime=60) == b"data"
 
 
 @pytest.mark.asyncio
-async def test_in_memory_remove(in_memory_store: SessionStore) -> None:
+async def test_in_memory_expires(in_memory_store: InMemoryStore) -> None:
+    # ttl=0 falls back to gc_ttl — data must be readable immediately
+    new_id = await in_memory_store.write("session_id", b"data", lifetime=0, ttl=0)
+    assert new_id == "session_id"
+    assert await in_memory_store.read("session_id", lifetime=60) == b"data"
+    assert len(in_memory_store.data) == 1
+
+    # ttl=1 — data is readable immediately
+    new_id = await in_memory_store.write("session_id", b"data", lifetime=0, ttl=1)
+    assert new_id == "session_id"
+    assert await in_memory_store.read("session_id", lifetime=60) == b"data"
+    assert len(in_memory_store.data) == 1
+
+
+@pytest.mark.asyncio
+async def test_in_memory_ttl_unit_is_seconds(in_memory_store: InMemoryStore) -> None:
+    """ttl is in seconds; simulates time advancing past the TTL via time_ns mock."""
+    base_ns = 1_000_000_000_000  # arbitrary starting point in ns
+    ttl_seconds = 30
+
+    with patch("starsessions.stores.memory.time") as mock_time:
+        mock_time.time_ns.return_value = base_ns
+        await in_memory_store.write("session_id", b"data", lifetime=60, ttl=ttl_seconds)
+
+        # before expiry: still within TTL
+        mock_time.time_ns.return_value = base_ns + (ttl_seconds - 1) * 1_000_000_000
+        assert await in_memory_store.read("session_id", lifetime=60) == b"data"
+
+        # after expiry: past TTL
+        mock_time.time_ns.return_value = base_ns + (ttl_seconds + 1) * 1_000_000_000
+        assert await in_memory_store.read("session_id", lifetime=60) == b""
+
+
+@pytest.mark.asyncio
+async def test_in_memory_remove(in_memory_store: InMemoryStore) -> None:
     await in_memory_store.write("session_id", b"data", lifetime=60, ttl=60)
     await in_memory_store.remove("session_id")
     assert await in_memory_store.read("session_id", lifetime=60) == b""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 from starsessions import InMemoryStore, JsonSerializer
+from starsessions.encryptors import Encryptor, NoopEncryptor
 
 
 @pytest.fixture
@@ -11,3 +12,8 @@ def serializer() -> JsonSerializer:
 @pytest.fixture
 def store() -> InMemoryStore:
     return InMemoryStore()
+
+
+@pytest.fixture
+def encryptor() -> Encryptor:
+    return NoopEncryptor()

--- a/tests/test_encryptors.py
+++ b/tests/test_encryptors.py
@@ -5,7 +5,6 @@ from starsessions.encryptors import AESGCMEncryptor, FernetEncryptor, NoopEncryp
 
 @pytest.fixture
 def aes_key() -> bytes:
-    # AESGCM requires 16, 24, or 32 byte key
     return b"\x00" * 32
 
 
@@ -16,63 +15,54 @@ def fernet_key() -> bytes:
     return Fernet.generate_key()
 
 
-@pytest.mark.asyncio
-async def test_noop_round_trip() -> None:
+def test_noop_round_trip() -> None:
     enc = NoopEncryptor()
     with pytest.warns(UserWarning, match="NoopEncryptor"):
-        assert await enc.decrypt(await enc.encrypt(b"hello")) == b"hello"
+        assert enc.decrypt(enc.encrypt(b"hello")) == b"hello"
 
 
 class TestFernetEncryptor:
-    @pytest.mark.asyncio
-    async def test_fernet_round_trip(self, fernet_key: bytes) -> None:
+    def test_fernet_round_trip(self, fernet_key: bytes) -> None:
         enc = FernetEncryptor(fernet_key)
         plaintext = b'{"user": "alice", "role": "admin"}'
-        assert await enc.decrypt(await enc.encrypt(plaintext)) == plaintext
+        assert enc.decrypt(enc.encrypt(plaintext)) == plaintext
 
-    @pytest.mark.asyncio
-    async def test_fernet_produces_unique_ciphertexts(self, fernet_key: bytes) -> None:
+    def test_fernet_produces_unique_ciphertexts(self, fernet_key: bytes) -> None:
         """Fernet uses a random IV; encrypting the same plaintext twice must differ."""
         enc = FernetEncryptor(fernet_key)
         plaintext = b"same data"
-        ct1 = await enc.encrypt(plaintext)
-        ct2 = await enc.encrypt(plaintext)
+        ct1 = enc.encrypt(plaintext)
+        ct2 = enc.encrypt(plaintext)
         assert ct1 != ct2
 
 
 class TestAESGCMEncryptor:
-    @pytest.mark.asyncio
-    async def test_aesgcm_round_trip(self, aes_key: bytes) -> None:
+    def test_aesgcm_round_trip(self, aes_key: bytes) -> None:
         enc = AESGCMEncryptor(aes_key)
         plaintext = b'{"user": "bob", "role": "user"}'
-        assert await enc.decrypt(await enc.encrypt(plaintext)) == plaintext
+        assert enc.decrypt(enc.encrypt(plaintext)) == plaintext
 
-    @pytest.mark.asyncio
-    async def test_aesgcm_nonce_is_random(self, aes_key: bytes) -> None:
+    def test_aesgcm_nonce_is_random(self, aes_key: bytes) -> None:
         enc = AESGCMEncryptor(aes_key)
         plaintext = b"same secret data"
-        ct1 = await enc.encrypt(plaintext)
-        ct2 = await enc.encrypt(plaintext)
-
-        # different ciphertexts because of different nonces
+        ct1 = enc.encrypt(plaintext)
+        ct2 = enc.encrypt(plaintext)
         assert ct1 != ct2
 
 
-@pytest.mark.asyncio
-async def test_aesgcm_empty_decrypt_returns_empty(aes_key: bytes) -> None:
+def test_aesgcm_empty_decrypt_returns_empty(aes_key: bytes) -> None:
     """Too-short input (< 12 bytes nonce) must not raise, just return empty."""
     enc = AESGCMEncryptor(aes_key)
-    assert await enc.decrypt(b"") == b""
-    assert await enc.decrypt(b"short") == b""
+    assert enc.decrypt(b"") == b""
+    assert enc.decrypt(b"short") == b""
 
 
-@pytest.mark.asyncio
-async def test_aesgcm_wrong_key_raises(aes_key: bytes) -> None:
+def test_aesgcm_wrong_key_raises(aes_key: bytes) -> None:
     """Decrypting with a different key must fail (authentication tag mismatch)."""
     from cryptography.exceptions import InvalidTag
 
     enc = AESGCMEncryptor(aes_key)
     other_enc = AESGCMEncryptor(b"\xff" * 32)
-    ciphertext = await enc.encrypt(b"secret")
+    ciphertext = enc.encrypt(b"secret")
     with pytest.raises(InvalidTag):
-        await other_enc.decrypt(ciphertext)
+        other_enc.decrypt(ciphertext)

--- a/tests/test_encryptors.py
+++ b/tests/test_encryptors.py
@@ -1,0 +1,78 @@
+import pytest
+
+from starsessions.encryptors import AESGCMEncryptor, FernetEncryptor, NoopEncryptor
+
+
+@pytest.fixture
+def aes_key() -> bytes:
+    # AESGCM requires 16, 24, or 32 byte key
+    return b"\x00" * 32
+
+
+@pytest.fixture
+def fernet_key() -> bytes:
+    from cryptography.fernet import Fernet
+
+    return Fernet.generate_key()
+
+
+@pytest.mark.asyncio
+async def test_noop_round_trip() -> None:
+    enc = NoopEncryptor()
+    with pytest.warns(UserWarning, match="NoopEncryptor"):
+        assert await enc.decrypt(await enc.encrypt(b"hello")) == b"hello"
+
+
+class TestFernetEncryptor:
+    @pytest.mark.asyncio
+    async def test_fernet_round_trip(self, fernet_key: bytes) -> None:
+        enc = FernetEncryptor(fernet_key)
+        plaintext = b'{"user": "alice", "role": "admin"}'
+        assert await enc.decrypt(await enc.encrypt(plaintext)) == plaintext
+
+    @pytest.mark.asyncio
+    async def test_fernet_produces_unique_ciphertexts(self, fernet_key: bytes) -> None:
+        """Fernet uses a random IV; encrypting the same plaintext twice must differ."""
+        enc = FernetEncryptor(fernet_key)
+        plaintext = b"same data"
+        ct1 = await enc.encrypt(plaintext)
+        ct2 = await enc.encrypt(plaintext)
+        assert ct1 != ct2
+
+
+class TestAESGCMEncryptor:
+    @pytest.mark.asyncio
+    async def test_aesgcm_round_trip(self, aes_key: bytes) -> None:
+        enc = AESGCMEncryptor(aes_key)
+        plaintext = b'{"user": "bob", "role": "user"}'
+        assert await enc.decrypt(await enc.encrypt(plaintext)) == plaintext
+
+    @pytest.mark.asyncio
+    async def test_aesgcm_nonce_is_random(self, aes_key: bytes) -> None:
+        enc = AESGCMEncryptor(aes_key)
+        plaintext = b"same secret data"
+        ct1 = await enc.encrypt(plaintext)
+        ct2 = await enc.encrypt(plaintext)
+
+        # different ciphertexts because of different nonces
+        assert ct1 != ct2
+
+
+@pytest.mark.asyncio
+async def test_aesgcm_empty_decrypt_returns_empty(aes_key: bytes) -> None:
+    """Too-short input (< 12 bytes nonce) must not raise, just return empty."""
+    enc = AESGCMEncryptor(aes_key)
+    assert await enc.decrypt(b"") == b""
+    assert await enc.decrypt(b"short") == b""
+
+
+@pytest.mark.asyncio
+async def test_aesgcm_wrong_key_raises(aes_key: bytes) -> None:
+    """Decrypting with a different key must fail (authentication tag mismatch)."""
+    from cryptography.exceptions import InvalidTag
+
+    enc = AESGCMEncryptor(aes_key)
+    other_enc = AESGCMEncryptor(b"\xff" * 32)
+    ciphertext = await enc.encrypt(b"secret")
+    with pytest.raises(InvalidTag):
+        await other_enc.decrypt(ciphertext)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -67,7 +67,7 @@ def test_load_should_not_overwrite_created_timestamp(store: SessionStore) -> Non
         assert client.get("/").json() == {
             "created": 42,
             "last_access": 1660556520,
-            "lifetime": 0,
+            "lifetime": 1209600,  # server-configured value always wins
         }
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,12 +1,14 @@
 import datetime
 
 import pytest
+from cryptography.fernet import Fernet
 from starlette.requests import HTTPConnection
 from starlette.responses import JSONResponse, Response
 from starlette.testclient import TestClient
 from starlette.types import Receive, Scope, Send
 
 from starsessions import SessionMiddleware, SessionStore
+from starsessions.encryptors import FernetEncryptor
 from starsessions.session import load_session
 
 
@@ -269,3 +271,142 @@ def test_session_timedelta_lifetime(store: SessionStore) -> None:
 
     app = SessionMiddleware(app, store=store, lifetime=datetime.timedelta(seconds=60))
     assert app.lifetime == 60
+
+
+def test_no_cookie_clear_outside_cookie_path(store: SessionStore) -> None:
+    """When cookie_path is set and the request path does not match, the expiry Set-Cookie must not be sent."""
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        connection = HTTPConnection(scope, receive)
+        await store.write("session_id", b'{"key": "value"}', lifetime=60, ttl=60)
+        await load_session(connection)
+        connection.session.clear()
+        response = Response("")
+        await response(scope, receive, send)
+
+    app = SessionMiddleware(app, store=store, cookie_path="/admin")
+    client = TestClient(app, cookies={"session": "session_id"})
+    response = client.get("/")
+    assert "set-cookie" not in response.headers
+
+
+def test_invalid_cookie_name_raises(store: SessionStore) -> None:
+    """cookie_name must only contain alphanumeric characters, hyphens, or underscores."""
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:  # pragma: nocover
+        pass
+
+    with pytest.raises(ValueError, match="Invalid cookie_name"):
+        SessionMiddleware(app, store=store, cookie_name="bad name; inject=1")
+
+    with pytest.raises(ValueError, match="Invalid cookie_name"):
+        SessionMiddleware(app, store=store, cookie_name="bad\r\nname")
+
+    # valid names must not raise
+    SessionMiddleware(app, store=store, cookie_name="session")
+    SessionMiddleware(app, store=store, cookie_name="my-session_v2")
+
+
+def test_unsafe_session_id_is_ignored(store: SessionStore) -> None:
+    """A cookie value with unsafe characters must be silently discarded."""
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        connection = HTTPConnection(scope, receive)
+        await load_session(connection)
+
+        response = JSONResponse(connection.session)
+        await response(scope, receive, send)
+
+    app = SessionMiddleware(app, store=store)
+    # value with newline — header-injection attempt
+    client = TestClient(app, cookies={"session": "abc\r\nSet-Cookie: evil=1"})
+    assert client.get("/").json() == {}
+
+
+def test_store_error_propagates(store: SessionStore) -> None:
+    """Errors from the store (e.g. Redis outage) must not be silently swallowed."""
+    from unittest.mock import AsyncMock
+
+    from starsessions.stores.base import SessionStore as BaseStore
+
+    broken_store = AsyncMock(spec=BaseStore)
+    broken_store.read.side_effect = RuntimeError("connection refused")
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        connection = HTTPConnection(scope, receive)
+        await load_session(connection)
+        response = JSONResponse(connection.session)
+        await response(scope, receive, send)
+
+    middleware = SessionMiddleware(app, store=broken_store, cookie_https_only=False, lifetime=60)
+    client = TestClient(middleware, cookies={"session": "some_id"}, raise_server_exceptions=True)
+    with pytest.raises(RuntimeError, match="connection refused"):
+        client.get("/")
+
+
+def test_tampered_ciphertext_yields_empty_session(store: SessionStore) -> None:
+    """A tampered or wrongly-keyed ciphertext must produce an empty session, not a 500."""
+    encryptor = FernetEncryptor(Fernet.generate_key())
+    wrong_encryptor = FernetEncryptor(Fernet.generate_key())
+
+    async def write_app(scope: Scope, receive: Receive, send: Send) -> None:
+        connection = HTTPConnection(scope, receive)
+        await load_session(connection)
+        connection.session["secret"] = "classified"
+        response = Response("")
+        await response(scope, receive, send)
+
+    async def read_app(scope: Scope, receive: Receive, send: Send) -> None:
+        connection = HTTPConnection(scope, receive)
+        await load_session(connection)
+        response = JSONResponse(connection.session)
+        await response(scope, receive, send)
+
+    write_middleware = SessionMiddleware(
+        write_app, store=store, encryptor=encryptor, cookie_https_only=False, lifetime=60
+    )
+    read_middleware = SessionMiddleware(
+        read_app, store=store, encryptor=wrong_encryptor, cookie_https_only=False, lifetime=60
+    )
+
+    write_response = TestClient(write_middleware, raise_server_exceptions=True).get("/")
+    session_cookie = write_response.cookies.get("session")
+    assert session_cookie is not None
+
+    result = TestClient(read_middleware, cookies={"session": session_cookie}, raise_server_exceptions=True).get("/")
+    assert result.status_code == 200
+    assert result.json() == {}
+
+
+def test_encryptor_round_trip_via_middleware(store: SessionStore) -> None:
+    """Data written through an encryptor must survive a full request round-trip."""
+    encryptor = FernetEncryptor(Fernet.generate_key())
+
+    async def write_app(scope: Scope, receive: Receive, send: Send) -> None:
+        connection = HTTPConnection(scope, receive)
+        await load_session(connection)
+        connection.session["secret"] = "classified"
+        response = Response("")
+        await response(scope, receive, send)
+
+    async def read_app(scope: Scope, receive: Receive, send: Send) -> None:
+        connection = HTTPConnection(scope, receive)
+        await load_session(connection)
+        response = JSONResponse(connection.session)
+        await response(scope, receive, send)
+
+    write_middleware = SessionMiddleware(
+        write_app, store=store, encryptor=encryptor, cookie_https_only=False, lifetime=60
+    )
+    read_middleware = SessionMiddleware(
+        read_app, store=store, encryptor=encryptor, cookie_https_only=False, lifetime=60
+    )
+
+    write_client = TestClient(write_middleware, raise_server_exceptions=True)
+    write_response = write_client.get("/")
+    session_cookie = write_response.cookies.get("session")
+    assert session_cookie is not None
+
+    read_client = TestClient(read_middleware, cookies={"session": session_cookie})
+    result = read_client.get("/")
+    assert result.json().get("secret") == "classified"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -2,6 +2,7 @@ import pytest
 from starlette.requests import HTTPConnection
 
 from starsessions import Serializer, SessionStore
+from starsessions.encryptors import Encryptor
 from starsessions.session import (
     SessionHandler,
     generate_session_id,
@@ -17,48 +18,86 @@ def test_generate_session_id() -> None:
     assert len(generate_session_id()) == 32
 
 
-def test_regenerate_session_id(store: SessionStore, serializer: Serializer) -> None:
+async def test_regenerate_session_id(store: SessionStore, serializer: Serializer, encryptor: Encryptor) -> None:
     scope = {"type": "http"}
     base_session_id = "some_id"
     connection = HTTPConnection(scope)
-    connection.scope["session"] = {}
-    connection.scope["session_handler"] = SessionHandler(connection, base_session_id, store, serializer, lifetime=60)
+    connection.scope["session"] = {"abc": "value"}
+    connection.scope["session_handler"] = SessionHandler(
+        connection, base_session_id, store, serializer, encryptor, lifetime=60
+    )
 
+    await store.write(base_session_id, b"value", 3600, 3600)
+    assert await store.read(base_session_id, 3600) == b"value"
     session_id = regenerate_session_id(connection)
     assert session_id
     assert session_id != base_session_id
 
 
-def test_get_session_id(store: SessionStore, serializer: Serializer) -> None:
+def test_get_session_id(store: SessionStore, serializer: Serializer, encryptor: Encryptor) -> None:
     scope = {"type": "http"}
     base_session_id = "some_id"
     connection = HTTPConnection(scope)
     connection.scope["session"] = {}
-    connection.scope["session_handler"] = SessionHandler(connection, base_session_id, store, serializer, lifetime=60)
+    connection.scope["session_handler"] = SessionHandler(
+        connection, base_session_id, store, serializer, encryptor, lifetime=60
+    )
 
     session_id = get_session_id(connection)
     assert session_id == base_session_id
 
 
-def test_get_session_handler(store: SessionStore, serializer: Serializer) -> None:
+def test_get_session_handler(store: SessionStore, serializer: Serializer, encryptor: Encryptor) -> None:
     scope = {"type": "http"}
     base_session_id = "some_id"
     connection = HTTPConnection(scope)
     connection.scope["session"] = {}
-    connection.scope["session_handler"] = SessionHandler(connection, base_session_id, store, serializer, lifetime=60)
+    connection.scope["session_handler"] = SessionHandler(
+        connection, base_session_id, store, serializer, encryptor, lifetime=60
+    )
 
     assert get_session_handler(connection) == connection.scope["session_handler"]
 
 
 @pytest.mark.asyncio
-async def test_load_session(store: SessionStore, serializer: Serializer) -> None:
+async def test_load_session(store: SessionStore, serializer: Serializer, encryptor: Encryptor) -> None:
     scope = {"type": "http"}
     base_session_id = "session_id"
     connection = HTTPConnection(scope)
     connection.scope["session"] = {}
-    connection.scope["session_handler"] = SessionHandler(connection, base_session_id, store, serializer, lifetime=60)
+    connection.scope["session_handler"] = SessionHandler(
+        connection, base_session_id, store, serializer, encryptor, lifetime=60
+    )
 
     await store.write("session_id", b'{"key": "value"}', lifetime=60, ttl=60)
     await load_session(connection)
     assert is_loaded(connection)
     assert connection.session == {"key": "value"}
+
+
+async def test_regenerate_id_removes_old_session_on_save(
+    store: SessionStore, serializer: Serializer, encryptor: Encryptor
+) -> None:
+    old_id = "old_session_id"
+    await store.write(old_id, b'{"key": "value"}', lifetime=60, ttl=60)
+
+    scope = {"type": "http"}
+    connection = HTTPConnection(scope)
+    connection.scope["session"] = {}
+    connection.scope["session_handler"] = SessionHandler(connection, old_id, store, serializer, encryptor, lifetime=60)
+
+    await load_session(connection)
+    handler = get_session_handler(connection)
+    handler.regenerate_id()
+    await handler.save(remaining_time=60)
+
+    assert await store.read(old_id, lifetime=60) == b""
+
+
+async def test_destroy_without_session_id(store: SessionStore, serializer: Serializer, encryptor: Encryptor) -> None:
+    scope = {"type": "http"}
+    connection = HTTPConnection(scope)
+    connection.scope["session"] = {}
+    connection.scope["session_handler"] = SessionHandler(connection, None, store, serializer, encryptor, lifetime=60)
+
+    await get_session_handler(connection).destroy()

--- a/uv.lock
+++ b/uv.lock
@@ -48,6 +48,101 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", version = "2.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and implementation_name != 'PyPy'" },
+    { name = "pycparser", version = "3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/08ed5a43f2996a16b462f64a7055c6e962803534924b9b2f1371d8c00b7b/cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf", size = 184288, upload-time = "2025-09-08T23:23:48.404Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/de/38d9726324e127f727b4ecc376bc85e505bfe61ef130eaf3f290c6847dd4/cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7", size = 180509, upload-time = "2025-09-08T23:23:49.73Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/13/c92e36358fbcc39cf0962e83223c9522154ee8630e1df7c0b3a39a8124e2/cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c", size = 208813, upload-time = "2025-09-08T23:23:51.263Z" },
+    { url = "https://files.pythonhosted.org/packages/15/12/a7a79bd0df4c3bff744b2d7e52cc1b68d5e7e427b384252c42366dc1ecbc/cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165", size = 216498, upload-time = "2025-09-08T23:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ad/5c51c1c7600bdd7ed9a24a203ec255dccdd0ebf4527f7b922a0bde2fb6ed/cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534", size = 203243, upload-time = "2025-09-08T23:23:53.836Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f2/81b63e288295928739d715d00952c8c6034cb6c6a516b17d37e0c8be5600/cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f", size = 203158, upload-time = "2025-09-08T23:23:55.169Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/74/cc4096ce66f5939042ae094e2e96f53426a979864aa1f96a621ad128be27/cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63", size = 216548, upload-time = "2025-09-08T23:23:56.506Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/be/f6424d1dc46b1091ffcc8964fa7c0ab0cd36839dd2761b49c90481a6ba1b/cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2", size = 218897, upload-time = "2025-09-08T23:23:57.825Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/e0/dda537c2309817edf60109e39265f24f24aa7f050767e22c98c53fe7f48b/cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65", size = 211249, upload-time = "2025-09-08T23:23:59.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e7/7c769804eb75e4c4b35e658dba01de1640a351a9653c3d49ca89d16ccc91/cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322", size = 218041, upload-time = "2025-09-08T23:24:00.496Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d9/6218d78f920dcd7507fc16a766b5ef8f3b913cc7aa938e7fc80b9978d089/cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a", size = 172138, upload-time = "2025-09-08T23:24:01.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/8f/a1e836f82d8e32a97e6b29cc8f641779181ac7363734f12df27db803ebda/cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9", size = 182794, upload-time = "2025-09-08T23:24:02.943Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -294,6 +389,66 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version >= '3.10' and python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289, upload-time = "2026-02-10T19:17:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
+    { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
+    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230, upload-time = "2026-02-10T19:17:30.518Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909, upload-time = "2026-02-10T19:17:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/00/13/3d278bfa7a15a96b9dc22db5a12ad1e48a9eb3d40e1827ef66a5df75d0d0/cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2", size = 7119287, upload-time = "2026-02-10T19:17:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c8/581a6702e14f0898a0848105cbefd20c058099e2c2d22ef4e476dfec75d7/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678", size = 4265728, upload-time = "2026-02-10T19:17:35.569Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/4a/ba1a65ce8fc65435e5a849558379896c957870dd64fecea97b1ad5f46a37/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87", size = 4408287, upload-time = "2026-02-10T19:17:36.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/67/8ffdbf7b65ed1ac224d1c2df3943553766914a8ca718747ee3871da6107e/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee", size = 4270291, upload-time = "2026-02-10T19:17:38.748Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/f52377ee93bc2f2bba55a41a886fd208c15276ffbd2569f2ddc89d50e2c5/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981", size = 4927539, upload-time = "2026-02-10T19:17:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/02/cfe39181b02419bbbbcf3abdd16c1c5c8541f03ca8bda240debc467d5a12/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9", size = 4442199, upload-time = "2026-02-10T19:17:41.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/96/2fcaeb4873e536cf71421a388a6c11b5bc846e986b2b069c79363dc1648e/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648", size = 3960131, upload-time = "2026-02-10T19:17:43.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/d2/b27631f401ddd644e94c5cf33c9a4069f72011821cf3dc7309546b0642a0/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4", size = 4270072, upload-time = "2026-02-10T19:17:45.481Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a7/60d32b0370dae0b4ebe55ffa10e8599a2a59935b5ece1b9f06edb73abdeb/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0", size = 4892170, upload-time = "2026-02-10T19:17:46.997Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b9/cf73ddf8ef1164330eb0b199a589103c363afa0cf794218c24d524a58eab/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663", size = 4441741, upload-time = "2026-02-10T19:17:48.661Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/eee00b28c84c726fe8fa0158c65afe312d9c3b78d9d01daf700f1f6e37ff/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826", size = 4396728, upload-time = "2026-02-10T19:17:50.058Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f4/6bc1a9ed5aef7145045114b75b77c2a8261b4d38717bd8dea111a63c3442/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d", size = 4652001, upload-time = "2026-02-10T19:17:51.54Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/5d00ef966ddd71ac2e6951d278884a84a40ffbd88948ef0e294b214ae9e4/cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a", size = 3003637, upload-time = "2026-02-10T19:17:52.997Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/f3f4160123da6d098db78350fdfd9705057aad21de7388eacb2401dceab9/cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4", size = 3469487, upload-time = "2026-02-10T19:17:54.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514, upload-time = "2026-02-10T19:17:56.267Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
+    { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
+    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
+    { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/dd/2d9fdb07cebdf3d51179730afb7d5e576153c6744c3ff8fded23030c204e/cryptography-46.0.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c", size = 3476964, upload-time = "2026-02-10T19:18:20.687Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/6f/6cc6cc9955caa6eaf83660b0da2b077c7fe8ff9950a3c5e45d605038d439/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a", size = 4218321, upload-time = "2026-02-10T19:18:22.349Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5d/c4da701939eeee699566a6c1367427ab91a8b7088cc2328c09dbee940415/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356", size = 4381786, upload-time = "2026-02-10T19:18:24.529Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/97/a538654732974a94ff96c1db621fa464f455c02d4bb7d2652f4edc21d600/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da", size = 4217990, upload-time = "2026-02-10T19:18:25.957Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/11/7e500d2dd3ba891197b9efd2da5454b74336d64a7cc419aa7327ab74e5f6/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257", size = 4381252, upload-time = "2026-02-10T19:18:27.496Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/58/6b3d24e6b9bc474a2dcdee65dfd1f008867015408a271562e4b690561a4d/cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7", size = 3407605, upload-time = "2026-02-10T19:18:29.233Z" },
 ]
 
 [[package]]
@@ -573,6 +728,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "2.23"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -746,6 +925,14 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "cryptography" },
+    { name = "redis", version = "7.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "redis", version = "7.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+cryptography = [
+    { name = "cryptography" },
+]
 redis = [
     { name = "redis", version = "7.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "redis", version = "7.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -753,6 +940,7 @@ redis = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "cryptography" },
     { name = "httpx" },
     { name = "mypy" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -766,14 +954,18 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cryptography", marker = "extra == 'all'", specifier = ">=42" },
+    { name = "cryptography", marker = "extra == 'cryptography'", specifier = ">=42" },
     { name = "itsdangerous", specifier = ">=2" },
+    { name = "redis", marker = "extra == 'all'", specifier = ">=4.2" },
     { name = "redis", marker = "extra == 'redis'", specifier = ">=4.2" },
     { name = "starlette", specifier = ">=0.14" },
 ]
-provides-extras = ["redis"]
+provides-extras = ["redis", "cryptography", "all"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "cryptography", specifier = ">=42" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "mypy", specifier = ">=1.14" },
     { name = "pytest", specifier = ">=8.0" },


### PR DESCRIPTION
## New features

- **Session encryption**: add `FernetEncryptor` and `AESGCMEncryptor` (AES-256-GCM with per-message random nonce). Pass to `SessionMiddleware(encryptor=...)`. Tampered or wrongly-keyed ciphertext yields an empty session; store errors propagate.
- **`CookieStore` size limit**: configurable `max_size` (default 4096 bytes) raises `ValueError` when session data would exceed the cookie limit.
- **Cookie name validation**: `SessionMiddleware` raises `ValueError` at init for `cookie_name` values outside `[a-zA-Z0-9_-]`.
- **Session ID validation**: cookie values with HTTP-unsafe characters are silently rejected, preventing header injection.
- **`InMemoryStore` TTL**: TTL is now stored and compared in nanoseconds via `time.time_ns()`. Session-only cookies (`ttl=0`) fall back to `gc_ttl`. Expired entries are actively evicted on every write.

## Bug fixes

- **Session fixation**: `regenerate_id()` now deletes the old session from the store before issuing a new ID.
- **Server-authoritative session lifetime**: stored `lifetime` metadata could override the server-configured value on load.
- **XSS in login example**: session username is now escaped with `html.escape`.